### PR TITLE
Added actions for API endpoints/models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2626,6 +2626,11 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         }
       }
     },
@@ -5035,6 +5040,11 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         }
       }
     },
@@ -9441,9 +9451,9 @@
       "integrity": "sha512-R7t6Y3fDDtcU7L4rtqwGUDP9xD64gJhIwpfjhRCTKmBoYF6SS49PIJHRJ048cse6OI7iwTwgyy2C46N9Ygoc6g=="
     },
     "qs": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+      "version": "6.9.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
+      "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw=="
     },
     "query-string": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Yohannes Ejigu",
   "private": true,
   "scripts": {
-    "dev": "nuxt",
+    "dev": "nuxt --port 8000",
     "build": "nuxt build",
     "start": "nuxt start",
     "generate": "nuxt generate",
@@ -28,6 +28,7 @@
     "nuxt": "^2.0.0",
     "nuxt-client-init-module": "^0.1.8",
     "nuxt-leaflet": "0.0.21",
+    "qs": "^6.9.3",
     "socket.io-client": "^2.3.0",
     "vue-apexcharts": "^1.5.2",
     "vue-chartjs": "^3.5.0",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -408,6 +408,11 @@ export default {
 
   methods: {
     ...mapActions("stats", { loadStats: "loadStats" }),
+    ...mapActions("auth", { getApiToken: "getApiToken" }),
+    ...mapActions("communities", { 
+      getAllCommunities: "getAllCommunities", 
+      getCommunity: "getCommunity" 
+    }),
     async getStats() {
       this.loading = true;
       try {
@@ -434,6 +439,13 @@ export default {
   },
   async mounted() {
     this.getStats();
+    this.getApiToken().then(() => {
+      this.getAllCommunities().then(() => {
+        // set up community related panels
+        // get model by id
+        // let record = this.getCommunity( { id: { id: "INSERT_ID_HERE" } } )
+      })
+    })
   }
 };
 </script>

--- a/plugins/auth.js
+++ b/plugins/auth.js
@@ -1,0 +1,27 @@
+import Vue from 'vue'
+
+class AuthService {
+  constructor(store) {
+    this.$store = store
+  }
+
+  get isAuthenticated() {
+    return this.$store.state.auth.isAuthenticated
+  }
+
+  get user() {
+    return this.$store.state.auth.user
+  }
+
+  get email() {
+    if (!this.user) return
+    return this.user.attributes.email
+  }
+}
+
+export default async ({ store }) => {
+  const authService = new AuthService(store)
+  Vue.prototype.$auth = authService
+  Vue.$auth = authService
+  await store.dispatch('auth/load')
+}

--- a/store/auth.js
+++ b/store/auth.js
@@ -47,6 +47,8 @@ export const actions = {
   },
 
   async getApiToken({ commit }) {
+    
+    let authUrl = process.env.AUTH_URL
     let clientId = process.env.CLIENT_ID
     let clientSecret = process.env.CLIENT_SECRET
     const AUTHORIZATION_KEY = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
@@ -59,7 +61,7 @@ export const actions = {
       }
     }
 
-    await axios.post('https://ethiopia-covid19.auth.us-east-2.amazoncognito.com/oauth2/token', data, headers)
+    await axios.post(authUrl, data, headers)
       .then(function (response) {
         commit("setApiToken", response.data.access_token);
       })

--- a/store/auth.js
+++ b/store/auth.js
@@ -51,19 +51,15 @@ export const actions = {
     let clientSecret = process.env.CLIENT_SECRET
     const AUTHORIZATION_KEY = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
 
-    let axiosConfig = {
-      method: 'post',
-      url: 'https://ethiopia-covid19.auth.us-east-2.amazoncognito.com/oauth2/token',
-      data: qs.stringify({
-        grant_type: 'client_credentials'
-      }),
+    let data = qs.stringify({ grant_type: 'client_credentials' })
+    let headers = {
       headers: {
         'content-type': 'application/x-www-form-urlencoded;charset=utf-8',
-        'Authorization': `Basic ${AUTHORIZATION_KEY}`,
+        'Authorization': `Basic ${AUTHORIZATION_KEY}`
       }
     }
 
-    await axios(axiosConfig)
+    await axios.post('https://ethiopia-covid19.auth.us-east-2.amazoncognito.com/oauth2/token', data, headers)
       .then(function (response) {
         commit("setApiToken", response.data.access_token);
       })

--- a/store/auth.js
+++ b/store/auth.js
@@ -47,8 +47,8 @@ export const actions = {
   },
 
   async getApiToken({ commit }) {
-    let clientId = ''
-    let clientSecret = ''
+    let clientId = process.env.CLIENT_ID
+    let clientSecret = process.env.CLIENT_SECRET
     const AUTHORIZATION_KEY = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
 
     let axiosConfig = {

--- a/store/communities.js
+++ b/store/communities.js
@@ -1,0 +1,57 @@
+const axios = require("axios").default;
+
+export const state = () => ({
+  allCommunities: []
+});
+
+export const mutations = {
+  set(state, data) {
+    state.allCommunities = data;
+  }
+};
+
+export const actions = {
+  async getAllCommunities({ commit, rootState }) {
+
+    let headers = {
+      headers: {
+        'content-type': 'application/json',
+        'Authorization': `Bearer ${rootState.auth.apiToken}`
+      }
+    }
+
+    await axios.get('https://api.ethiopia-covid19.com/gateway/communities', headers)
+      .then(function (response) {
+        commit("set", response.data.result);
+      })
+      .catch(function (error) {
+        console.log(error);
+
+        commit("set", []);
+      });
+  },
+
+  async getCommunity( { commit, rootState }, { id } ) {
+    
+    let headers = {
+      headers: {
+        'content-type': 'application/json',
+        'Authorization': `Bearer ${rootState.auth.apiToken}`
+      }
+    }
+
+    await axios.get(`https://api.ethiopia-covid19.com/gateway/communities/${id.id}`, headers)
+      .then(function (response) {
+        return response.data
+      })
+      .catch(function (error) {
+        console.log(error);
+      });
+  }
+};
+
+export const getters = {
+  getAllCommunities: state => {
+    return state.allCommunities;
+  }
+};

--- a/store/communities.js
+++ b/store/communities.js
@@ -13,6 +13,7 @@ export const mutations = {
 export const actions = {
   async getAllCommunities({ commit, rootState }) {
 
+    let productionUrl = process.env.PRODUCTION_URL
     let headers = {
       headers: {
         'content-type': 'application/json',
@@ -20,7 +21,7 @@ export const actions = {
       }
     }
 
-    await axios.get('https://api.ethiopia-covid19.com/gateway/communities', headers)
+    await axios.get(`${productionUrl}/gateway/communities`, headers)
       .then(function (response) {
         commit("set", response.data.result);
       })
@@ -33,6 +34,7 @@ export const actions = {
 
   async getCommunity( { commit, rootState }, { id } ) {
     
+    let productionUrl = process.env.PRODUCTION_URL
     let headers = {
       headers: {
         'content-type': 'application/json',
@@ -40,7 +42,7 @@ export const actions = {
       }
     }
 
-    await axios.get(`https://api.ethiopia-covid19.com/gateway/communities/${id.id}`, headers)
+    await axios.get(`${productionUrl}/gateway/communities/${id.id}`, headers)
       .then(function (response) {
         return response.data
       })

--- a/store/medical-facilities.js
+++ b/store/medical-facilities.js
@@ -1,0 +1,39 @@
+const axios = require("axios").default;
+
+export const state = () => ({
+  allMedicalFacilities: []
+});
+
+export const mutations = {
+  set(state, data) {
+    state.allMedicalFacilities = data;
+  }
+};
+
+export const actions = {
+  async getAllMedicalFacilities({ commit, rootState }) {
+
+    let headers = {
+      headers: {
+        'content-type': 'application/json',
+        'Authorization': `Bearer ${rootState.auth.apiToken}`
+      }
+    }
+
+    await axios.get('https://api.ethiopia-covid19.com/gateway/medical-facilities', headers)
+      .then(function (response) {
+        commit("set", response.data.result);
+      })
+      .catch(function (error) {
+        console.log(error);
+
+        commit("set", []);
+      });
+  }
+};
+
+export const getters = {
+  getAllMedicalFacilities: state => {
+    return state.allMedicalFacilities;
+  }
+};

--- a/store/medical-facilities.js
+++ b/store/medical-facilities.js
@@ -13,6 +13,7 @@ export const mutations = {
 export const actions = {
   async getAllMedicalFacilities({ commit, rootState }) {
 
+    let productionUrl = process.env.PRODUCTION_URL
     let headers = {
       headers: {
         'content-type': 'application/json',
@@ -20,7 +21,7 @@ export const actions = {
       }
     }
 
-    await axios.get('https://api.ethiopia-covid19.com/gateway/medical-facilities', headers)
+    await axios.get(`${productionUrl}/gateway/medical-facilities`, headers)
       .then(function (response) {
         commit("set", response.data.result);
       })

--- a/store/passengers.js
+++ b/store/passengers.js
@@ -1,0 +1,39 @@
+const axios = require("axios").default;
+
+export const state = () => ({
+  allPassengers: []
+});
+
+export const mutations = {
+  set(state, data) {
+    state.allPassengers = data;
+  }
+};
+
+export const actions = {
+  async getAllPassengers({ commit, rootState }) {
+
+    let headers = {
+      headers: {
+        'content-type': 'application/json',
+        'Authorization': `Bearer ${rootState.auth.apiToken}`,
+      }
+    }
+
+    await axios.get('https://api.ethiopia-covid19.com/gateway/passengers', headers)
+      .then(function (response) {
+        commit("set", response.data.result);
+      })
+      .catch(function (error) {
+        console.log(error);
+
+        commit("set", []);
+      });
+  }
+};
+
+export const getters = {
+  getAllPassengers: state => {
+    return state.allPassengers;
+  }
+};

--- a/store/passengers.js
+++ b/store/passengers.js
@@ -13,6 +13,7 @@ export const mutations = {
 export const actions = {
   async getAllPassengers({ commit, rootState }) {
 
+    let productionUrl = process.env.PRODUCTION_URL
     let headers = {
       headers: {
         'content-type': 'application/json',
@@ -20,7 +21,7 @@ export const actions = {
       }
     }
 
-    await axios.get('https://api.ethiopia-covid19.com/gateway/passengers', headers)
+    await axios.get(`${productionUrl}/gateway/passengers`, headers)
       .then(function (response) {
         commit("set", response.data.result);
       })

--- a/store/surveillance.js
+++ b/store/surveillance.js
@@ -1,0 +1,39 @@
+const axios = require("axios").default;
+
+export const state = () => ({
+  allSurveillance: []
+});
+
+export const mutations = {
+  set(state, data) {
+    state.allSurveillance = data;
+  }
+};
+
+export const actions = {
+  async getAllSurveillance({ commit, rootState }) {
+
+    let headers = {
+      headers: {
+        'content-type': 'application/json',
+        'Authorization': `Bearer ${rootState.auth.apiToken}`
+      }
+    }
+
+    await axios.get('https://api.ethiopia-covid19.com/gateway/surveillance', headers)
+      .then(function (response) {
+        commit("set", response.data.result);
+      })
+      .catch(function (error) {
+        console.log(error);
+
+        commit("set", []);
+      });
+  }
+};
+
+export const getters = {
+  getAllSurveillance: state => {
+    return state.allSurveillance;
+  }
+};

--- a/store/surveillance.js
+++ b/store/surveillance.js
@@ -13,6 +13,7 @@ export const mutations = {
 export const actions = {
   async getAllSurveillance({ commit, rootState }) {
 
+    let productionUrl = process.env.PRODUCTION_URL
     let headers = {
       headers: {
         'content-type': 'application/json',
@@ -20,7 +21,7 @@ export const actions = {
       }
     }
 
-    await axios.get('https://api.ethiopia-covid19.com/gateway/surveillance', headers)
+    await axios.get(`${productionUrl}/gateway/surveillance`, headers)
       .then(function (response) {
         commit("set", response.data.result);
       })

--- a/store/toll-free.js
+++ b/store/toll-free.js
@@ -1,0 +1,39 @@
+const axios = require("axios").default;
+
+export const state = () => ({
+  allTollFree: []
+});
+
+export const mutations = {
+  set(state, data) {
+    state.allTollFree = data;
+  }
+};
+
+export const actions = {
+  async getAllTollFree({ commit, rootState }) {
+
+    let headers = {
+      headers: {
+        'content-type': 'application/json',
+        'Authorization': `Bearer ${rootState.auth.apiToken}`
+      }
+    }
+
+    await axios.get('https://api.ethiopia-covid19.com/gateway/toll-free', headers)
+      .then(function (response) {
+        commit("set", response.data.result);
+      })
+      .catch(function (error) {
+        console.log(error);
+
+        commit("set", []);
+      });
+  }
+};
+
+export const getters = {
+  getAllTollFree: state => {
+    return state.allTollFree;
+  }
+};

--- a/store/toll-free.js
+++ b/store/toll-free.js
@@ -13,6 +13,7 @@ export const mutations = {
 export const actions = {
   async getAllTollFree({ commit, rootState }) {
 
+    let productionUrl = process.env.PRODUCTION_URL
     let headers = {
       headers: {
         'content-type': 'application/json',
@@ -20,7 +21,7 @@ export const actions = {
       }
     }
 
-    await axios.get('https://api.ethiopia-covid19.com/gateway/toll-free', headers)
+    await axios.get(`${productionUrl}/gateway/toll-free`, headers)
       .then(function (response) {
         commit("set", response.data.result);
       })


### PR DESCRIPTION
Added API for those available at the moment (communities, passengers, medical facilities, surveillance, toll-free) models and index endpoints to actions and to keep in the store. Would update the endpoints as environment variables if we know the values, the dev endpoints are currently in there for this commit. Added index/get all routes, should make additional tickets for pagination or specific ID/get/show routes when needed.